### PR TITLE
Fixes #29

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Version 0.11
+
+ *  Issue in `dbWriteTable()` with temporary files on Windows fixed.
+
 # Version 0.10
 
  *  New maintainer: Jeroen Ooms

--- a/R/table.R
+++ b/R/table.R
@@ -175,7 +175,7 @@ setMethod("dbWriteTable", c("MySQLConnection", "character", "character"),
       dbGetQuery(conn, sql)
     }
 
-    path <- normalizePath(value, mustWork = TRUE)
+    path <- normalizePath(value, winslash = "/", mustWork = TRUE)
     sql <- paste0(
       "LOAD DATA LOCAL INFILE ", dbQuoteString(conn, path), "\n",
       "INTO TABLE ", dbQuoteIdentifier(conn, name), "\n",

--- a/R/table.R
+++ b/R/table.R
@@ -131,7 +131,7 @@ setMethod("dbWriteTable", c("MySQLConnection", "character", "data.frame"),
     if (nrow(value) == 0) return(TRUE)
 
     ## Save file to disk, then use LOAD DATA command
-    fn <- normalizePath(tempfile("rsdbi"), mustWork = FALSE)
+    fn <- normalizePath(tempfile("rsdbi"), winslash = "/", mustWork = FALSE)
     safe.write(value, file = fn)
     on.exit(unlink(fn), add = TRUE)
 


### PR DESCRIPTION
My proposed fix to issue #29 works. This is the change. I guess all other normalizePath() commands need the same winslash = "/", but I did not implement or test that.