### PR TITLE
Fix dbWriteTable and temporary tables, #10

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -196,7 +196,14 @@ setMethod("dbListTables", "MySQLConnection", function(conn, ...) {
 #' @rdname mysql-tables
 setMethod("dbExistsTable", c("MySQLConnection", "character"),
   function(conn, name, ...) {
-    name %in% dbListTables(conn)
+    tryCatch({
+      dbGetQuery(conn, paste0(
+        "SELECT NULL FROM ", dbQuoteIdentifier(conn, name), " WHERE FALSE"
+      ))
+      TRUE
+    }, error = function(...) {
+      FALSE
+    })
   }
 )
 

--- a/R/table.R
+++ b/R/table.R
@@ -52,7 +52,8 @@ setMethod("dbReadTable", c("MySQLConnection", "character"),
 #' @param overwrite a logical specifying whether to overwrite an existing table
 #'   or not. Its default is \code{FALSE}. (See the BUGS section below)
 #' @param append a logical specifying whether to append to an existing table
-#'   in the DBMS.  Its default is \code{FALSE}.
+#'   in the DBMS.  If appending, then the table (or temporary table)
+#'   must exist, otherwise an error is reported. Its default is \code{FALSE}.
 #' @param allow.keywords DEPRECATED.
 #' @export
 #' @rdname mysql-tables
@@ -78,6 +79,9 @@ setMethod("dbWriteTable", c("MySQLConnection", "character", "data.frame"),
     }
     if (found && overwrite) {
       dbRemoveTable(conn, name)
+    }
+    if (!found && append) {
+      stop("Table ", name, " does not exists when appending")
     }
 
     if (!found || overwrite) {
@@ -154,6 +158,9 @@ setMethod("dbWriteTable", c("MySQLConnection", "character", "character"),
     }
     if (found && overwrite) {
       dbRemoveTable(conn, name)
+    }
+    if (!found && append) {
+      stop("Table ", name, " does not exists when appending")
     }
 
     if (!found || overwrite) {

--- a/tests/testthat/test-dbWriteTable.R
+++ b/tests/testthat/test-dbWriteTable.R
@@ -84,8 +84,30 @@ test_that("can read file from disk", {
     stringsAsFactors = FALSE
   )
 
-  dbWriteTable(con, "dat", "dat-n.txt", sep = "|", eol = "\n", temporary = TRUE)
+  dbWriteTable(con, "dat", "dat-n.txt", sep = "|", eol = "\n",
+               temporary = TRUE, overwrite = TRUE)
   expect_equal(dbReadTable(con, "dat"), expected)
+
+  dbDisconnect(con)
+})
+
+test_that("temporary tables work properly", {
+  con <- mysqlDefault()
+
+  df <- data.frame(
+    str = letters[1:5],
+    num = 1:5,
+    stringsAsFactors = FALSE
+  )
+  dbWriteTable(con, "dat", df, temporary = TRUE, row.names = FALSE)
+  res <- dbGetQuery(con, "SELECT * FROM dat")
+  expect_equal(res, df)
+
+  dbGetQuery(con, "DELETE FROM dat")
+  expect_true(dbWriteTable(con, "dat", df, append = TRUE, row.names = FALSE))
+
+  res <- dbGetQuery(con, "SELECT * FROM dat")
+  expect_equal(res, df)
 
   dbDisconnect(con)
 })

--- a/tests/testthat/test-dbWriteTable.R
+++ b/tests/testthat/test-dbWriteTable.R
@@ -91,6 +91,25 @@ test_that("can read file from disk", {
   dbDisconnect(con)
 })
 
+test_that("appending is error if table does not exist", {
+  con <- mysqlDefault()
+
+  df <- data.frame(
+    str = letters[1:5],
+    num = 1:5,
+    stringsAsFactors = FALSE
+  )
+  dbWriteTable(con, "dat", df, overwrite = TRUE)
+
+  expect_error(
+    dbWriteTable(con, "dat", df, overwrite = FALSE, append = FALSE),
+    "Table dat exists"
+  )
+
+  dbRemoveTable(con, "dat")
+  dbDisconnect(con)
+})
+
 test_that("temporary tables work properly", {
   con <- mysqlDefault()
 
@@ -108,6 +127,11 @@ test_that("temporary tables work properly", {
 
   res <- dbGetQuery(con, "SELECT * FROM dat")
   expect_equal(res, df)
+
+  expect_error(
+    dbWriteTable(con, "dat", df, append = FALSE, row.names = FALSE),
+    "Table dat exists"
+  )
 
   dbDisconnect(con)
 })


### PR DESCRIPTION
Also, `append = TRUE` now does not create the table if it does not exist, but returns an error. These two changes were discussed together in #10, but they are actually independent, imo. The new `append = TRUE` behavior might break existing code that relies on the current behavior, so maybe we don't want that.

As for the temporary table part, the only sane way to check if a temporary or regular table exists, is to run a `SELECT` on it, seemingly. :( This might be problematic if the user has privs to run `SHOW TABLES`, but not the `SELECT`. This does not happen very often I guess, and here we are trying to write to a table, anyway, although that is again a different priv.

What to you think? This is probably too much ado about too little, but wanted to "finish" it, nevertheless.