### PR TITLE
Allow password to be NULL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Depends:
     DBI (>= 0.3.1.9007)
 Imports:
     methods,
-    Rcpp
+    Rcpp (>= 0.12.1)
 License: GPL-2
 URL: https://github.com/rstats-db/rmysql,
     https://downloads.mariadb.org/connector-c/

--- a/R/connect.R
+++ b/R/connect.R
@@ -50,17 +50,17 @@ NULL
 #' }
 #' @export
 setMethod("dbConnect", "MySQLDriver",
-  function(drv, dbname = "", username = "", password = "", host = "",
-    unix.socket = "", port = 0, client.flag = 0,
-    groups = "rs-dbi", default.file = "", ...) {
+  function(drv, dbname = NULL, username = NULL, password = NULL, host = NULL,
+    unix.socket = NULL, port = 0, client.flag = 0,
+    groups = "rs-dbi", default.file = NULL, ...) {
 
     ptr <- connection_create(host, username, password, dbname, port, unix.socket,
       client.flag, groups, default.file)
 
     con <- new("MySQLConnection",
       ptr = ptr,
-      host = host,
-      db = dbname
+      host = if(is.null(host)) NA_character_ else host,
+      db = if(is.null(dbname)) NA_character_ else dbname
     )
 
     dbGetQuery(con, 'SET time_zone = "+00:00"')

--- a/src/MyConnection.h
+++ b/src/MyConnection.h
@@ -18,10 +18,15 @@ class MyConnection : boost::noncopyable {
 
 public:
 
-  MyConnection(std::string host, std::string user, std::string password,
-               std::string db, unsigned int port, std::string unix_socket,
-               unsigned long client_flag, std::string groups,
-               std::string default_file) :
+  MyConnection(Rcpp::Nullable < std::string > host,
+               Rcpp::Nullable < std::string > user,
+               Rcpp::Nullable < std::string > password,
+               Rcpp::Nullable < std::string > db,
+               unsigned int port,
+               Rcpp::Nullable < std::string > unix_socket,
+               unsigned long client_flag,
+               Rcpp::Nullable < std::string > groups,
+               Rcpp::Nullable < std::string > default_file) :
     pCurrentResult_(NULL)
   {
 
@@ -30,15 +35,21 @@ public:
     mysql_options(pConn_, MYSQL_OPT_LOCAL_INFILE, 0);
     // Default to UTF-8
     mysql_options(pConn_, MYSQL_SET_CHARSET_NAME, "UTF8");
-    if (groups != "")
-      mysql_options(pConn_, MYSQL_READ_DEFAULT_GROUP, groups.c_str());
-    if (default_file != "")
-      mysql_options(pConn_, MYSQL_READ_DEFAULT_FILE, default_file.c_str());
+    if (!groups.isNull())
+      mysql_options(pConn_, MYSQL_READ_DEFAULT_GROUP,
+                    Rcpp::as<std::string>(groups).c_str());
+    if (!default_file.isNull())
+      mysql_options(pConn_, MYSQL_READ_DEFAULT_FILE,
+                    Rcpp::as<std::string>(default_file).c_str());
 
-
-    if (!mysql_real_connect(pConn_, host.c_str(), user.c_str(),
-        password.c_str(), db == "" ? NULL : db.c_str(), port,
-        unix_socket == "" ? NULL : unix_socket.c_str(), client_flag)) {
+    if (!mysql_real_connect(pConn_,
+        host.isNull() ? NULL : Rcpp::as<std::string>(host).c_str(),
+        user.isNull() ? NULL : Rcpp::as<std::string>(user).c_str(),
+        password.isNull() ? NULL : Rcpp::as<std::string>(password).c_str(),
+        db.isNull() ? NULL : Rcpp::as<std::string>(db).c_str(),
+        port,
+        unix_socket.isNull() ? NULL : Rcpp::as<std::string>(unix_socket).c_str(),
+        client_flag)) {
       mysql_close(pConn_);
       Rcpp::stop("Failed to connect: %s", mysql_error(pConn_));
     }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -7,20 +7,20 @@
 using namespace Rcpp;
 
 // connection_create
-XPtr<MyConnectionPtr> connection_create(std::string host, std::string user, std::string password, std::string db, unsigned int port, std::string unix_socket, unsigned long client_flag, std::string groups, std::string default_file);
+XPtr<MyConnectionPtr> connection_create(Rcpp::Nullable < std::string > host, Rcpp::Nullable < std::string > user, Rcpp::Nullable < std::string > password, Rcpp::Nullable < std::string > db, unsigned int port, Rcpp::Nullable < std::string > unix_socket, unsigned long client_flag, Rcpp::Nullable < std::string > groups, Rcpp::Nullable < std::string > default_file);
 RcppExport SEXP RMySQL_connection_create(SEXP hostSEXP, SEXP userSEXP, SEXP passwordSEXP, SEXP dbSEXP, SEXP portSEXP, SEXP unix_socketSEXP, SEXP client_flagSEXP, SEXP groupsSEXP, SEXP default_fileSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
-    Rcpp::traits::input_parameter< std::string >::type host(hostSEXP);
-    Rcpp::traits::input_parameter< std::string >::type user(userSEXP);
-    Rcpp::traits::input_parameter< std::string >::type password(passwordSEXP);
-    Rcpp::traits::input_parameter< std::string >::type db(dbSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable < std::string > >::type host(hostSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable < std::string > >::type user(userSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable < std::string > >::type password(passwordSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable < std::string > >::type db(dbSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type port(portSEXP);
-    Rcpp::traits::input_parameter< std::string >::type unix_socket(unix_socketSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable < std::string > >::type unix_socket(unix_socketSEXP);
     Rcpp::traits::input_parameter< unsigned long >::type client_flag(client_flagSEXP);
-    Rcpp::traits::input_parameter< std::string >::type groups(groupsSEXP);
-    Rcpp::traits::input_parameter< std::string >::type default_file(default_fileSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable < std::string > >::type groups(groupsSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable < std::string > >::type default_file(default_fileSEXP);
     __result = Rcpp::wrap(connection_create(host, user, password, db, port, unix_socket, client_flag, groups, default_file));
     return __result;
 END_RCPP

--- a/src/connnection.cpp
+++ b/src/connnection.cpp
@@ -3,15 +3,16 @@
 using namespace Rcpp;
 
 // [[Rcpp::export]]
-XPtr<MyConnectionPtr> connection_create(std::string host,
-                                        std::string user,
-                                        std::string password,
-                                        std::string db,
-                                        unsigned int port,
-                                        std::string unix_socket,
-                                        unsigned long client_flag,
-                                        std::string groups,
-                                        std::string default_file) {
+XPtr<MyConnectionPtr> connection_create(
+    Rcpp::Nullable < std::string > host,
+    Rcpp::Nullable < std::string > user,
+    Rcpp::Nullable < std::string > password,
+    Rcpp::Nullable < std::string > db,
+    unsigned int port,
+    Rcpp::Nullable < std::string > unix_socket,
+    unsigned long client_flag,
+    Rcpp::Nullable < std::string > groups,
+    Rcpp::Nullable < std::string > default_file) {
   MyConnectionPtr* pConn = new MyConnectionPtr(
     new MyConnection(host, user, password, db, port, unix_socket, client_flag,
       groups, default_file)


### PR DESCRIPTION
With the port to Rcpp/C++ (starting with commit b74b697396), the
default value for `password` in `dbConnect` method `MySQLDriver`
changed from `NULL` to `""`. This was probably necessary because a
C++ `std::string` cannot be `NULL`. However, the MySQL C API function
`mysql_real_connect` does accept `NULL` and even requires it for a
password to be read from an option file:

> Then, in the `mysql_real_connect()` call, specify the “no-value”
> value for each parameter to be read from an option file:
> [..]
> - For `passwd`, specify a value of `NULL`. (For the password, a
> value of the empty string in the `mysql_real_connect()` call cannot
> be overridden in an option file, because the empty string indicates
> explicitly that the MySQL account must have an empty password.)
>
> -- [MySQL 5.7 Reference Manual, 22.8.7.54 mysql_real_connect()]
> (https://dev.mysql.com/doc/refman/5.7/en/mysql-real-connect.html)

This patch will again allow, and use as default, `NULL` as parameter
value for `password`. This is accomplished by 'splitting' a bool
variable `password_null` off from `password` before calling the C++
code and 'merging' the two back together in the call to the MySQL C
code.

Possible alternatives:
- http://stackoverflow.com/questions/341743/c-string-that-can-be-null
- [boost::optional]
(http://www.boost.org/doc/libs/1_59_0/libs/optional/doc/html/index.html)

Fixes #55