### PR TITLE
Fix repetition of strings in subsequent rows

### DIFF
--- a/src/MyRow.h
+++ b/src/MyRow.h
@@ -188,10 +188,10 @@ public:
 private:
   void fetchBuffer(int j) {
     unsigned long length = lengths_[j];
+    buffers_[j].resize(length);
     if (length == 0)
       return;
 
-    buffers_[j].resize(length);
     bindings_[j].buffer = &buffers_[j][0]; // might have moved
     bindings_[j].buffer_length = length;
 


### PR DESCRIPTION
Columns containing string types (VARCHAR, LONGTEXT, etc.) may contain
an empty string (string of length 0). In case the string length of a
particular field is known to be 0, there is of course no need to fetch
the actual string. That is why `MyRow.h`, `fetchBuffer()` does an
early return in case it finds `length == 0`.

However, if `buffers_[j]` is not changed to reflect the empty value,
it will still contain the value from the previous row, which will then
be returned as the field value for the current row, instead of the
empty string that it actually contains.

This patch corrects `fetchBuffer()` by resizing `buffers_[j]` earlier,
that is before a possible early return in case of length 0.

Fixes rstats-db/RMySQL#65
Fixes rstats-db/RMySQL#87
Fixes rstats-db/RMySQL#124