### PR TITLE
Fix R CMD check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(person("Jeroen", "Ooms", email = "jeroen.ooms@stat.ucla.edu", role 
     person("RStudio", role = "cph"))
 Depends:
     R (>= 2.8.0),
-    DBI (>= 0.3.1)
+    DBI (>= 0.4)
 Imports:
     methods
 License: GPL-2

--- a/R/result.R
+++ b/R/result.R
@@ -16,6 +16,8 @@ setAs("MySQLResult", "MySQLConnection", function(from) {
 
 mysqlFetch <- function(res, n, ...) {
   rel <- .Call(RS_MySQL_fetch, res@Id, nrec = as.integer(n))
+  if (is.null(rel))
+    return(data.frame())
 
   if (length(rel) > 0) {
     n <- length(rel[[1]])

--- a/R/table.R
+++ b/R/table.R
@@ -180,9 +180,9 @@ setMethod("dbWriteTable", c("MySQLConnection", "character", "character"),
     sql <- paste0(
       "LOAD DATA LOCAL INFILE ", dbQuoteString(conn, path), "\n",
       "INTO TABLE ", dbQuoteIdentifier(conn, name), "\n",
-      "FIELDS TERMINATED BY ", dbQuoteString(conn, encodeString(sep)), "\n",
+      "FIELDS TERMINATED BY ", dbQuoteString(conn, sep), "\n",
       "OPTIONALLY ENCLOSED BY ", dbQuoteString(conn, quote), "\n",
-      "LINES TERMINATED BY ", dbQuoteString(conn, encodeString(eol)), "\n",
+      "LINES TERMINATED BY ", dbQuoteString(conn, eol), "\n",
       "IGNORE ", skip + as.integer(header), " LINES")
     dbSendQuery(conn, sql)
 

--- a/src/result.c
+++ b/src/result.c
@@ -259,7 +259,7 @@ SEXP RS_MySQL_fetch(SEXP rsHandle, SEXP max_rec) {
   result = RS_DBI_getResultSet(rsHandle);
   flds = result->fields;
   if(!flds)
-    error("corrupt resultSet, missing fieldDescription");
+    return R_NilValue;
   num_rec = asInteger(max_rec);
   expand = (num_rec < 0);   // dyn expand output to accommodate all rows
   if(expand || num_rec == 0){


### PR DESCRIPTION
- don't need to call encodeString for dbQuoteString() anymore
- as of DBI 0.4, bump DBI dependency

Fixes #141, fixes #142.